### PR TITLE
fix: concatenate in the correct order

### DIFF
--- a/src/pages/ResultsLanding/ResultsLanding.tsx
+++ b/src/pages/ResultsLanding/ResultsLanding.tsx
@@ -45,7 +45,7 @@ const ResultsLanding: React.FC = () => {
     fetchUserHistory(query,page)
       .then((res:any) => res.json())
       .then((res:any) => {
-        setResults(res.results.concat(results));
+        setResults(results.concat(res.results));
 
         if (res.nbPages === page) { // we have reached the end
           setPage(-1);


### PR DESCRIPTION
When it fetched the new results it was adding them on top so you kept seeing the old results when scrolling down.  
Now it adds them at the bottom.  